### PR TITLE
Allow user to remain logged in when closing their browser.

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,6 @@
 class SessionsController < ApplicationController
   before_action :redirect_if_authenticated, only: [:create, :new]
+  before_action :authenticate_user!, only: [:destroy]
 
   def create
     @user = User.find_by(email: params[:user][:email].downcase)
@@ -8,6 +9,7 @@ class SessionsController < ApplicationController
         redirect_to new_confirmation_path, alert: "You must confirm your email before you can sign in."
       elsif @user.authenticate(params[:user][:password])
         login @user
+        remember(@user) if params[:user][:remember_me] == "1"
         redirect_to root_path, notice: "Signed in."
       else
         flash[:alert] = "Incorrect email or password."
@@ -20,6 +22,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
+    forget(current_user)
     logout
     redirect_to root_path, notice: "Singed out."
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   has_secure_password
   has_secure_token :confirmation_token
   has_secure_token :password_reset_token
+  has_secure_token :remember_token
 
   before_save :downcase_email
   before_save :downcase_unconfirmed_email

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -8,8 +8,8 @@
     <%= form.password_field :password, required: true %>
   </div>
   <div>
-    <%= form.label :password_confirmation %>
-    <%= form.password_field :password_confirmation, required: true %>
+    <%= form.label :remember_me %>
+    <%= form.check_box :remember_me %>
   </div>
   <%= form.submit %>
 <% end %>

--- a/db/migrate/20211205165850_add_remember_token_to_users.rb
+++ b/db/migrate/20211205165850_add_remember_token_to_users.rb
@@ -1,0 +1,6 @@
+class AddRememberTokenToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :remember_token, :string, null: false
+    add_index :users, :remember_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_03_155851) do
+ActiveRecord::Schema.define(version: 2021_12_05_165850) do
 
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
@@ -23,9 +23,11 @@ ActiveRecord::Schema.define(version: 2021_12_03_155851) do
     t.string "password_reset_token", null: false
     t.datetime "password_reset_sent_at"
     t.string "unconfirmed_email"
+    t.string "remember_token", null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["password_reset_token"], name: "index_users_on_password_reset_token", unique: true
+    t.index ["remember_token"], name: "index_users_on_remember_token", unique: true
   end
 
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -28,6 +28,37 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
     assert_equal @confirmed_user, current_user
   end
+
+  test "should remember user when logging in" do
+    assert_nil cookies[:remember_token]
+
+    post login_path, params: {
+      user: {
+        email: @confirmed_user.email,
+        password: @confirmed_user.password,
+        remember_me: 1
+      }
+    }
+
+    assert_not_nil current_user
+    assert_not_nil cookies[:remember_token]
+  end
+
+  test "should forget user when logging out" do
+    login @confirmed_user, remember_user: true
+
+    delete logout_path
+   
+    # FIXME: Expected "" to be nil.
+    # When I run byebug in SessionsController#destroy cookies[:remember_token] does == nil. 
+    # I think this might be a bug in Rails?
+    # assert_nil cookies[:remember_token]
+    assert cookies[:remember_token].blank?
+    assert_nil current_user
+    assert_redirected_to root_path
+    assert_not_nil flash[:notice]
+  end
+
   
   test "should not login if unconfirmed" do
     post login_path, params: {

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,13 +14,15 @@ class ActiveSupport::TestCase
     session[:current_user_id] && User.find_by(id: session[:current_user_id])
   end
 
-  def login(user)
+  def login(user, remember_user: nil)
     post login_path, params: {
       user: {
         email: user.email,
-        password: user.password
+        password: user.password,
+        remember_me: remember_user == true ? 1 : 0
       }
     }
+
   end
 
   def logout


### PR DESCRIPTION
Issues
------

- Closes #5

Changelog
---------

- Add `remember_token` column to `users` table.
- Add `forget` and `remember` methods to `Authentication` concern.
- Update `login` test helper.
- Add "Remember me" checkbox to login form.