### PR TITLE
Invert return value of confirmed? method in the unconfirmed? method

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ class User < ApplicationRecord
   end
 
   def unconfirmed?
-    confirmed_at.nil?
+    !confirmed?
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,7 +63,7 @@ class User < ApplicationRecord
   end
 
   def unconfirmed?
-    confirmed_at.nil?
+    !confirmed?
   end
 
   def unconfirmed_or_reconfirming?


### PR DESCRIPTION
Since the `confirmed?` method already exists and is using the `present?` method to check if the `confirmed_at` attribute is nil/empty or not, we can instead invert the return value of the `confirmed?` method in the `unconfirmed?` method as calling `nil?` would return true on an empty string if such a case were to arise.