### PR TITLE
Add strategy for session replay attacks.

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -14,7 +14,8 @@ module Authentication
 
   def login(user)
     reset_session
-    session[:current_user_id] = user.id
+    user.regenerate_session_token
+    session[:current_user_session_token] = user.reload.session_token
   end
 
   def forget(user)
@@ -23,7 +24,9 @@ module Authentication
   end
 
   def logout
+    user = current_user
     reset_session
+    user.regenerate_session_token
   end
 
   def redirect_if_authenticated
@@ -42,8 +45,8 @@ module Authentication
   private
 
   def current_user
-    Current.user = if session[:current_user_id].present?
-      User.find_by(id: session[:current_user_id])
+    Current.user = if session[:current_user_session_token].present?
+      User.find_by(session_token: session[:current_user_session_token])
     elsif cookies.permanent.encrypted[:remember_token].present?
       User.find_by(remember_token: cookies.permanent.encrypted[:remember_token])
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   has_secure_token :confirmation_token
   has_secure_token :password_reset_token
   has_secure_token :remember_token
+  has_secure_token :session_token
 
   before_save :downcase_email
   before_save :downcase_unconfirmed_email

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).

--- a/db/migrate/20211217184706_add_session_token_to_users.rb
+++ b/db/migrate/20211217184706_add_session_token_to_users.rb
@@ -1,0 +1,6 @@
+class AddSessionTokenToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :session_token, :string, null: false
+    add_index :users, :session_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_05_165850) do
+ActiveRecord::Schema.define(version: 2021_12_17_184706) do
 
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
@@ -24,10 +24,12 @@ ActiveRecord::Schema.define(version: 2021_12_05_165850) do
     t.datetime "password_reset_sent_at"
     t.string "unconfirmed_email"
     t.string "remember_token", null: false
+    t.string "session_token", null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["password_reset_token"], name: "index_users_on_password_reset_token", unique: true
     t.index ["remember_token"], name: "index_users_on_remember_token", unique: true
+    t.index ["session_token"], name: "index_users_on_session_token", unique: true
   end
 
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -26,7 +26,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       }
     }
     assert_redirected_to root_path
-    assert_equal @confirmed_user, current_user
+    assert_equal @confirmed_user.email, current_user.email
   end
 
   test "should remember user when logging in" do
@@ -97,5 +97,19 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     delete logout_path
     assert_redirected_to root_path
+  end
+
+  test "should reset session_token when logging out" do
+    login @confirmed_user
+
+    assert_changes "@confirmed_user.reload.session_token" do
+      delete logout_path
+    end
+  end
+
+  test "should reset session_token when logging in" do
+    assert_changes "@confirmed_user.reload.session_token" do
+      login @confirmed_user
+    end
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -203,4 +203,10 @@ class UserTest < ActiveSupport::TestCase
       assert_equal Time.current, @unconfirmed_user.reload.confirmed_at
     end
   end
+
+  test "should set session_token on create" do
+    @user.save!
+
+    assert_not_nil @user.reload.session_token
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ class ActiveSupport::TestCase
 
   # Add more helper methods to be used by all tests here...
   def current_user
-    session[:current_user_id] && User.find_by(id: session[:current_user_id])
+    session[:current_user_session_token] && User.find_by(session_token: session[:current_user_session_token])
   end
 
   def login(user, remember_user: nil)


### PR DESCRIPTION
Changelog
---------

- Add `session_token` column to users table.
- Use `session_token` to identify users through the session.
- Regenerate `session_token` on login and logout.
- Set `config.force_ssl = true`.

Issues
------

- Closes #18