### PR TITLE
Update User model for missing self in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ class User < ApplicationRecord
   private
 
   def downcase_email
-    email = email.downcase
+    self.email = email.downcase
   end
 end
 ```
@@ -141,7 +141,7 @@ class User < ApplicationRecord
   private
 
   def downcase_email
-    email = email.downcase
+    self.email = email.downcase
   end
 end
 ```


### PR DESCRIPTION
Notice that in `downcase_email` ... `self` is missing. The provided [application](https://github.com/stevepolitodesign/rails-authentication-from-scratch/blob/0afd9bb7eb625c6a8ea1161c53305396437995b8/app/models/user.rb#L95) shows it correctly:

```ruby
def downcase_email
   email = email.downcase
end
```