### PR TITLE
Improve method name for better clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ class User < ApplicationRecord
     confirmed_at.present?
   end
 
-  def confirmation_token_has_not_expired?
+  def confirmation_token_is_valid?
     return false if confirmation_sent_at.nil?
     (Time.current - confirmation_sent_at) <= User::CONFIRMATION_TOKEN_EXPIRATION_IN_SECONDS
   end
@@ -152,7 +152,7 @@ end
 > - The `has_secure_token :confirmation_token` method is added to give us an [API](https://api.rubyonrails.org/classes/ActiveRecord/SecureToken/ClassMethods.html#method-i-has_secure_token) to work with the `confirmation_token` column.
 > - The `confirm!` method will be called when a user confirms their email address. We still need to build this feature.
 > - The `confirmed?` and `unconfirmed?` methods allow us to tell whether a user has confirmed their email address or not.
-> - The `confirmation_token_has_not_expired?` method tells us if the confirmation token is expired or not. This can be controlled by changing the value of the `CONFIRMATION_TOKEN_EXPIRATION_IN_SECONDS` constant. This will be useful when we build the confirmation mailer.
+> - The `confirmation_token_is_valid?` method tells us if the confirmation token is expired or not. This can be controlled by changing the value of the `CONFIRMATION_TOKEN_EXPIRATION_IN_SECONDS` constant. This will be useful when we build the confirmation mailer.
 
 ## Step 3: Create Sign Up Pages
 
@@ -263,7 +263,7 @@ class ConfirmationsController < ApplicationController
   def edit
     @user = User.find_by(confirmation_token: params[:confirmation_token])
 
-    if @user.present? && @user.confirmation_token_has_not_expired?
+    if @user.present? && @user.confirmation_token_is_valid?
       @user.confirm!
       redirect_to root_path, notice: "Your account has been confirmed."
     else
@@ -581,7 +581,7 @@ class ConfirmationsController < ApplicationController
 
   def edit
     ...
-    if @user.present? && @user.confirmation_token_has_not_expired?
+    if @user.present? && @user.confirmation_token_is_valid?
       @user.confirm!
       login @user
       ...
@@ -886,7 +886,7 @@ class ConfirmationsController < ApplicationController
   ...
   def edit
     ...
-    if @user.present? && @user.unconfirmed_or_reconfirming? && @user.confirmation_token_has_not_expired?
+    if @user.present? && @user.unconfirmed_or_reconfirming? && @user.confirmation_token_is_valid?
       if @user.confirm!
         login @user
         redirect_to root_path, notice: "Your account has been confirmed."
@@ -1047,7 +1047,7 @@ class ConfirmationsController < ApplicationController
   ...
   def edit
     ...
-    if @user.present? && @user.unconfirmed_or_reconfirming? && @user.confirmation_token_has_not_expired?
+    if @user.present? && @user.unconfirmed_or_reconfirming? && @user.confirmation_token_is_valid?
       ...
     end
   end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -14,7 +14,7 @@ class ConfirmationsController < ApplicationController
 
   def edit
     @user = User.find_by(confirmation_token: params[:confirmation_token])
-    if @user.present? && @user.unconfirmed_or_reconfirming? && @user.confirmation_token_has_not_expired?
+    if @user.present? && @user.unconfirmed_or_reconfirming? && @user.confirmation_token_is_valid?
       if @user.confirm!
         login @user
         redirect_to root_path, notice: "Your account has been confirmed."

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,7 +55,7 @@ class User < ApplicationRecord
     end
   end
 
-  def confirmation_token_has_not_expired?
+  def confirmation_token_is_valid?
     return false if confirmation_sent_at.nil?
     (Time.current - confirmation_sent_at) <= User::CONFIRMATION_TOKEN_EXPIRATION_IN_SECONDS
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -107,14 +107,14 @@ class UserTest < ActiveSupport::TestCase
     assert_equal @user.unconfirmed_email, ActionMailer::Base.deliveries.last.to[0]
   end
 
-  test "should respond to confirmation_token_has_not_expired?" do
-    assert_not @user.confirmation_token_has_not_expired?
+  test "should respond to confirmation_token_is_valid?" do
+    assert_not @user.confirmation_token_is_valid?
 
     @user.confirmation_sent_at = 1.minute.ago
-    assert @user.confirmation_token_has_not_expired?
+    assert @user.confirmation_token_is_valid?
 
     @user.confirmation_sent_at = 601.seconds.ago
-    assert_not @user.confirmation_token_has_not_expired?
+    assert_not @user.confirmation_token_is_valid?
   end
 
   test "should respond to send_password_reset_email!" do


### PR DESCRIPTION
The orignal `confirmation_token_has_not_expired?` is a negative sentence that might return false which makes you think twice.

Issues
------
- Closes #33