### PR TITLE
Rotate password reset tokens after successful password reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,6 +748,7 @@ class PasswordsController < ApplicationController
       elsif @user.password_reset_token_has_expired?
         redirect_to new_password_path, alert: "Incorrect email or password."
       elsif @user.update(password_params)
+        @user.regenerate_password_reset_token
         redirect_to login_path, notice: "Signed in."
       else
         flash.now[:alert] = @user.errors.full_messages.to_sentence
@@ -775,6 +776,7 @@ end
 > - The `new` action simply renders a form for the user to put their email address in to receive the password reset email.
 > - The `update` also ensures the user is identified by their `password_reset_token`. It's not enough to just do this on the `edit` action since a bad actor could make a `PUT` request to the server and bypass the form.
 >   - If the user exists and is confirmed and their password token has not expired, we update their password to the one they will set in the form. Otherwise, we handle each failure case differently.
+>   - Note that we call `@user.regenerate_password_reset_token` to ensure their `password_reset_token` is reset so that it cannot be used again.
 
 2. Update Routes.
 

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -35,6 +35,7 @@ class PasswordsController < ApplicationController
       elsif @user.password_reset_token_has_expired?
         redirect_to new_password_path, alert: "Incorrect email or password."
       elsif @user.update(password_params)
+        @user.regenerate_password_reset_token
         redirect_to login_path, notice: "Password updated."
       else
         flash.now[:alert] = @user.errors.full_messages.to_sentence

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -73,12 +73,14 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   test "should update password" do
     @confirmed_user.send_password_reset_email!
 
-    put password_path(@confirmed_user.password_reset_token), params: {
-      user: {
-        password: "password",
-        password_confirmation: "password"
+    assert_changes "@confirmed_user.reload.password_reset_token" do
+      put password_path(@confirmed_user.password_reset_token), params: {
+        user: {
+          password: "password",
+          password_confirmation: "password"
+        }
       }
-    }
+    end
 
     assert_redirected_to login_path
     assert_not_nil flash[:notice]


### PR DESCRIPTION
This ensures the token cannot be used again. We have an expiration on this value, but doing a reset is more secure.

Issues
------
- Closes #49