### PR TITLE
Prevent leaking email addresses when user is not confirmed

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ class SessionsController < ApplicationController
     @user = User.find_by(email: params[:user][:email].downcase)
     if @user
       if @user.unconfirmed?
-        redirect_to new_confirmation_path, alert: "You must confirm your email before you can sign in."
+        redirect_to new_confirmation_path, alert: "Incorrect email or password."
       elsif @user.authenticate(params[:user][:password])
         login @user
         redirect_to root_path, notice: "Signed in."
@@ -576,6 +576,7 @@ end
 > - The `create` method simply checks if the user exists and is confirmed. If they are, then we check their password. If the password is correct, we log them in via the `login` method we created in the `Authentication` Concern. Otherwise, we render an alert.
 >   - We're able to call `user.authenticate` because of [has_secure_password](https://api.rubyonrails.org/classes/ActiveModel/SecurePassword/ClassMethods.html#method-i-has_secure_password)
 >   - Note that we call `downcase` on the email to account for case sensitivity when searching.
+>   - Note that we set the flash to "Incorrect email or password." if the user is unconfirmed. This prevents leaking email addresses.
 > - The `destroy` method simply calls the `logout` method we created in the `Authentication` Concern.
 > - The login form is passed a `scope: :user` option so that the params are namespaced as `params[:user][:some_value]`. This is not required, but it helps keep things organized.
 
@@ -1321,7 +1322,7 @@ class SessionsController < ApplicationController
     @user = User.authenticate_by(email: params[:user][:email].downcase, password: params[:user][:password])
     if @user
       if @user.unconfirmed?
-        redirect_to new_confirmation_path, alert: "You must confirm your email before you can sign in."
+        redirect_to new_confirmation_path, alert: "Incorrect email or password."
       else
         after_login_path = session[:user_return_to] || root_path
         login @user

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < ApplicationController
     @user = User.authenticate_by(email: params[:user][:email].downcase, password: params[:user][:password])
     if @user
       if @user.unconfirmed?
-        redirect_to new_confirmation_path, alert: "You must confirm your email before you can sign in."
+        redirect_to new_confirmation_path, alert: "Incorrect email or password."
       else
         after_login_path = session[:user_return_to] || root_path
         login @user

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -66,7 +66,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
         password: @unconfirmed_user.password
       }
     }
-    assert_not_nil flash[:alert]
+    assert_equal "Incorrect email or password.", flash[:alert]
     assert_nil current_user
     assert_redirected_to new_confirmation_path
   end


### PR DESCRIPTION
A bad actor could exploit this vulnerability to see if a user exists in the system.

Issues
------
- Closes #51