### PR TITLE
Use signed_id to confirm user.

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -13,8 +13,8 @@ class ConfirmationsController < ApplicationController
   end
 
   def edit
-    @user = User.find_by(confirmation_token: params[:confirmation_token])
-    if @user.present? && @user.unconfirmed_or_reconfirming? && @user.confirmation_token_is_valid?
+    @user = User.find_signed(params[:confirmation_token], purpose: :confirm_email)
+    if @user.present? && @user.unconfirmed_or_reconfirming?
       if @user.confirm!
         login @user
         redirect_to root_path, notice: "Your account has been confirmed."

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -6,8 +6,9 @@ class UserMailer < ApplicationMailer
   #
   #   en.user_mailer.confirmation.subject
   #
-  def confirmation(user)
+  def confirmation(user, confirmation_token)
     @user = user
+    @confirmation_token = confirmation_token
 
     mail to: @user.confirmable_email, subject: "Confirmation Instructions"
   end

--- a/app/views/user_mailer/confirmation.html.erb
+++ b/app/views/user_mailer/confirmation.html.erb
@@ -1,3 +1,3 @@
 <h1>Confirmation Instructions</h1>
 
-<%= link_to "Click here to confirm your email.", edit_confirmation_url(@user.confirmation_token) %>
+<%= link_to "Click here to confirm your email.", edit_confirmation_url(@confirmation_token) %>

--- a/app/views/user_mailer/confirmation.text.erb
+++ b/app/views/user_mailer/confirmation.text.erb
@@ -1,3 +1,3 @@
 Confirmation Instructions
 
-<%= edit_confirmation_url(@user.confirmation_token) %>
+<%= edit_confirmation_url(@confirmation_token) %>

--- a/db/migrate/20211112152821_add_confirmation_and_password_columns_to_users.rb
+++ b/db/migrate/20211112152821_add_confirmation_and_password_columns_to_users.rb
@@ -1,17 +1,6 @@
 class AddConfirmationAndPasswordColumnsToUsers < ActiveRecord::Migration[6.1]
   def change
-    # This will be used to identify a user in a secure way. We don't ever want it to be empty.
-    # This value will automatically be set on save.
-    # https://api.rubyonrails.org/classes/ActiveRecord/SecureToken/ClassMethods.html#method-i-has_secure_token
-    add_column :users, :confirmation_token, :string, null: false
-    add_column :users, :confirmation_sent_at, :datetime
     add_column :users, :confirmed_at, :datetime
-
-    # This will store the hashed value of the password. We don't ever want it to be empty.
-    # https://api.rubyonrails.org/classes/ActiveModel/SecurePassword/ClassMethods.html#method-i-has_secure_password
     add_column :users, :password_digest, :string, null: false
-
-    # This will ensure the confirmation_token is unique.
-    add_index :users, :confirmation_token, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,8 +16,6 @@ ActiveRecord::Schema.define(version: 2021_12_17_184706) do
     t.string "email", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "confirmation_token", null: false
-    t.datetime "confirmation_sent_at"
     t.datetime "confirmed_at"
     t.string "password_digest", null: false
     t.string "password_reset_token", null: false
@@ -25,7 +23,6 @@ ActiveRecord::Schema.define(version: 2021_12_17_184706) do
     t.string "unconfirmed_email"
     t.string "remember_token", null: false
     t.string "session_token", null: false
-    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["password_reset_token"], name: "index_users_on_password_reset_token", unique: true
     t.index ["remember_token"], name: "index_users_on_remember_token", unique: true

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -6,11 +6,12 @@ class UserMailerTest < ActionMailer::TestCase
   end
 
   test "confirmation" do
-    mail = UserMailer.confirmation(@user)
+    confirmation_token = @user.generate_confirmation_token
+    mail = UserMailer.confirmation(@user, confirmation_token)
     assert_equal "Confirmation Instructions", mail.subject
     assert_equal [@user.email], mail.to
     assert_equal [User::MAILER_FROM_EMAIL], mail.from
-    assert_match @user.confirmation_token, mail.body.encoded
+    assert_match confirmation_token, mail.body.encoded
   end
 
   test "password_reset" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -74,47 +74,25 @@ class UserTest < ActiveSupport::TestCase
     assert @user.unconfirmed_or_reconfirming?
   end
 
-  test "should confirm email" do
+  test "should send confirmation email" do
     @user.save!
-    original_confirmation_token = @user.confirmation_token
-
-    freeze_time
-
-    assert_nil @user.confirmation_sent_at
 
     assert_emails 1 do
       @user.send_confirmation_email!
     end
 
-    assert_not_equal original_confirmation_token, @user.reload.confirmation_token
-    assert_equal Time.now, @user.confirmation_sent_at
     assert_equal @user.email, ActionMailer::Base.deliveries.last.to[0]
   end
 
-  test "should confirm unconfirmed_email" do
+  test "should send confirmation email to unconfirmed_email" do
     @user.save!
     @user.update!(unconfirmed_email: "unconfirmed_email@example.com")
-    previous_confirmation_token = @user.reload.confirmation_token
-
-    freeze_time
 
     assert_emails 1 do
       @user.send_confirmation_email!
     end
 
-    assert_not_equal previous_confirmation_token, @user.reload.confirmation_token
-    assert_equal Time.now, @user.confirmation_sent_at
     assert_equal @user.unconfirmed_email, ActionMailer::Base.deliveries.last.to[0]
-  end
-
-  test "should respond to confirmation_token_is_valid?" do
-    assert_not @user.confirmation_token_is_valid?
-
-    @user.confirmation_sent_at = 1.minute.ago
-    assert @user.confirmation_token_is_valid?
-
-    @user.confirmation_sent_at = 601.seconds.ago
-    assert_not @user.confirmation_token_is_valid?
   end
 
   test "should respond to send_password_reset_email!" do


### PR DESCRIPTION
This is more secure, and also requires less columns.