### PR TITLE
Forget user when deleting an associated active session

### DIFF
--- a/app/controllers/active_sessions_controller.rb
+++ b/app/controllers/active_sessions_controller.rb
@@ -2,6 +2,7 @@ class ActiveSessionsController < ApplicationController
   before_action :authenticate_user!
 
   def destroy
+    user = current_user
     @active_session = current_user.active_sessions.find(params[:id])
 
     @active_session.destroy
@@ -9,6 +10,7 @@ class ActiveSessionsController < ApplicationController
     if current_user
       redirect_to account_path, notice: "Session deleted."
     else
+      forget(user)
       reset_session
       redirect_to root_path, notice: "Signed out."
     end
@@ -17,6 +19,7 @@ class ActiveSessionsController < ApplicationController
   def destroy_all
     current_user
 
+    forget(current_user)
     current_user.active_sessions.destroy_all
     reset_session
 

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -16,11 +16,12 @@ module Authentication
     reset_session
     active_session = user.active_sessions.create!(user_agent: request.user_agent, ip_address: request.ip)
     session[:current_active_session_id] = active_session.id
+
+    active_session
   end
 
   def forget(user)
     cookies.delete :remember_token
-    user.regenerate_remember_token
   end
 
   def logout
@@ -33,9 +34,8 @@ module Authentication
     redirect_to root_path, alert: "You are already logged in." if user_signed_in?
   end
 
-  def remember(user)
-    user.regenerate_remember_token
-    cookies.permanent.encrypted[:remember_token] = user.remember_token
+  def remember(active_session)
+    cookies.permanent.encrypted[:remember_token] = active_session.remember_token
   end
 
   def store_location
@@ -48,7 +48,7 @@ module Authentication
     Current.user = if session[:current_active_session_id].present?
       ActiveSession.find_by(id: session[:current_active_session_id])&.user
     elsif cookies.permanent.encrypted[:remember_token].present?
-      User.find_by(remember_token: cookies.permanent.encrypted[:remember_token])
+      ActiveSession.find_by(remember_token: cookies.permanent.encrypted[:remember_token])&.user
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,8 +9,8 @@ class SessionsController < ApplicationController
         redirect_to new_confirmation_path, alert: "Incorrect email or password."
       else
         after_login_path = session[:user_return_to] || root_path
-        login @user
-        remember(@user) if params[:user][:remember_me] == "1"
+        active_session = login @user
+        remember(active_session) if params[:user][:remember_me] == "1"
         redirect_to after_login_path, notice: "Signed in."
       end
     else

--- a/app/models/active_session.rb
+++ b/app/models/active_session.rb
@@ -1,3 +1,5 @@
 class ActiveSession < ApplicationRecord
   belongs_to :user
+
+  has_secure_token :remember_token
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,6 @@ class User < ApplicationRecord
   attr_accessor :current_password
 
   has_secure_password
-  has_secure_token :remember_token
 
   has_many :active_sessions, dependent: :destroy
 

--- a/db/migrate/20220204201046_move_remember_token_from_users_to_active_sessions.rb
+++ b/db/migrate/20220204201046_move_remember_token_from_users_to_active_sessions.rb
@@ -1,0 +1,10 @@
+# TODO: Remove comment
+# rails g migration move_remember_token_from_users_to_active_sessions
+class MoveRememberTokenFromUsersToActiveSessions < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :remember_token
+    add_column :active_sessions, :remember_token, :string, null: false
+
+    add_index :active_sessions, :remember_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_01_102359) do
+ActiveRecord::Schema.define(version: 2022_02_04_201046) do
 
   create_table "active_sessions", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -18,6 +18,8 @@ ActiveRecord::Schema.define(version: 2022_02_01_102359) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "user_agent"
     t.string "ip_address"
+    t.string "remember_token", null: false
+    t.index ["remember_token"], name: "index_active_sessions_on_remember_token", unique: true
     t.index ["user_id"], name: "index_active_sessions_on_user_id"
   end
 
@@ -28,9 +30,7 @@ ActiveRecord::Schema.define(version: 2022_02_01_102359) do
     t.datetime "confirmed_at"
     t.string "password_digest", null: false
     t.string "unconfirmed_email"
-    t.string "remember_token", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["remember_token"], name: "index_users_on_remember_token", unique: true
   end
 
   add_foreign_key "active_sessions", "users", on_delete: :cascade

--- a/test/controllers/active_sessions_controller_test.rb
+++ b/test/controllers/active_sessions_controller_test.rb
@@ -18,6 +18,18 @@ class ActiveSessionsControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil flash[:notice]
   end
 
+  test "should destroy all active sessions and forget active sessions" do
+    login @confirmed_user, remember_user: true
+    @confirmed_user.active_sessions.create!
+
+    assert_difference("ActiveSession.count", -2) do
+      delete destroy_all_active_sessions_path
+    end
+
+    assert_nil current_user
+    assert cookies[:remember_token].blank?
+  end
+
   test "should destroy another session" do
     login @confirmed_user
     @confirmed_user.active_sessions.create!
@@ -41,5 +53,16 @@ class ActiveSessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
     assert_nil current_user
     assert_not_nil flash[:notice]
+  end
+
+  test "should destroy current session and forget current active session" do
+    login @confirmed_user, remember_user: true
+
+    assert_difference("ActiveSession.count", -1) do
+      delete active_session_path(@confirmed_user.active_sessions.last)
+    end
+
+    assert_nil current_user
+    assert cookies[:remember_token].blank?
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,12 @@ class ActiveSupport::TestCase
 
   # Add more helper methods to be used by all tests here...
   def current_user
-    session[:current_active_session_id] && ActiveSession.find_by(id: session[:current_active_session_id])&.user
+    if session[:current_active_session_id].present?
+      ActiveSession.find_by(id: session[:current_active_session_id])&.user
+    else
+      cookies[:remember_token].present?
+      ActiveSession.find_by(remember_token: cookies[:remember_token])&.user
+    end
   end
 
   def login(user, remember_user: nil)


### PR DESCRIPTION
When deleting an active session I want to ensure the associated session is forgotten so that I can ensure my account it safe.

Issues
------
- Closes #78