### PR TITLE
Use correct input type when collecting email addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ end
   <%= render partial: "shared/form_errors", locals: { object: form.object } %>
   <div>
     <%= form.label :email %>
-    <%= form.text_field :email, required: true %>
+    <%= form.email_field :email, required: true %>
   </div>
   <div>
     <%= form.label :password %>
@@ -557,7 +557,7 @@ end
 <%= form_with url: login_path, scope: :user do |form| %>
   <div>
     <%= form.label :email %>
-    <%= form.text_field :email, required: true %>
+    <%= form.email_field :email, required: true %>
   </div>
   <div>
     <%= form.label :password %>
@@ -992,7 +992,7 @@ end
   <%= render partial: "shared/form_errors", locals: { object: form.object } %>
   <div>
     <%= form.label :email, "Current Email" %>
-    <%= form.text_field :email, disabled: true %>
+    <%= form.email_field :email, disabled: true %>
   </div>
   <div>
     <%= form.label :unconfirmed_email, "New Email" %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <%= form_with url: login_path, scope: :user do |form| %>
   <div>
     <%= form.label :email %>
-    <%= form.text_field :email, required: true %>
+    <%= form.email_field :email, required: true %>
   </div>
   <div>
     <%= form.label :password %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -2,7 +2,7 @@
   <%= render partial: "shared/form_errors", locals: { object: form.object } %>
   <div>
     <%= form.label :email, "Current Email" %>
-    <%= form.text_field :email, disabled: true %>
+    <%= form.email_field :email, disabled: true %>
   </div>
   <div>
     <%= form.label :unconfirmed_email, "New Email" %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,7 +2,7 @@
   <%= render partial: "shared/form_errors", locals: { object: form.object } %>
   <div>
     <%= form.label :email %>
-    <%= form.text_field :email, required: true %>
+    <%= form.email_field :email, required: true %>
   </div>
   <div>
     <%= form.label :password %>


### PR DESCRIPTION
When filling out a form that collects an email address, I want my email to be validated in the browser so that I don’t find out it was incorrectly formatted when submitting the form.

Issues
------
- Closes #73