### PR TITLE
Reorder controller methods to enhance developer experience and improve readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ rails g controller Users
 # app/controllers/users_controller.rb
 class UsersController < ApplicationController
 
+  def new
+    @user = User.new
+  end
+  
   def create
     @user = User.new(user_params)
     if @user.save
@@ -183,10 +187,6 @@ class UsersController < ApplicationController
     else
       render :new, status: :unprocessable_entity
     end
-  end
-
-  def new
-    @user = User.new
   end
 
   private
@@ -254,6 +254,10 @@ rails g controller Confirmations
 # app/controllers/confirmations_controller.rb
 class ConfirmationsController < ApplicationController
 
+  def new
+    @user = User.new
+  end
+
   def create
     @user = User.find_by(email: params[:user][:email].downcase)
 
@@ -273,10 +277,6 @@ class ConfirmationsController < ApplicationController
     else
       redirect_to new_confirmation_path, alert: "Invalid token."
     end
-  end
-
-  def new
-    @user = User.new
   end
 
 end
@@ -509,6 +509,9 @@ rails g controller Sessions
 class SessionsController < ApplicationController
   before_action :redirect_if_authenticated, only: [:create, :new]
 
+  def new
+  end
+
   def create
     @user = User.find_by(email: params[:user][:email].downcase)
     if @user
@@ -530,9 +533,6 @@ class SessionsController < ApplicationController
   def destroy
     logout
     redirect_to root_path, notice: "Signed out."
-  end
-
-  def new
   end
 
 end
@@ -676,6 +676,9 @@ rails g controller Passwords
 # app/controllers/passwords_controller.rb
 class PasswordsController < ApplicationController
   before_action :redirect_if_authenticated
+  
+  def new
+  end
 
   def create
     @user = User.find_by(email: params[:user][:email].downcase)
@@ -698,9 +701,6 @@ class PasswordsController < ApplicationController
     elsif @user.nil?
       redirect_to new_password_path, alert: "Invalid or expired token."
     end
-  end
-
-  def new
   end
 
   def update
@@ -920,12 +920,6 @@ class UsersController < ApplicationController
     ...
   end
 
-  def destroy
-    current_user.destroy
-    reset_session
-    redirect_to root_path, notice: "Your account has been deleted."
-  end
-
   def edit
     @user = current_user
   end
@@ -947,6 +941,12 @@ class UsersController < ApplicationController
       flash.now[:error] = "Incorrect password"
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    current_user.destroy
+    reset_session
+    redirect_to root_path, notice: "Your account has been deleted."
   end
 
   private

--- a/README.md
+++ b/README.md
@@ -730,11 +730,11 @@ end
 
 > **What's Going On Here?**
 >
+> - The `new` action simply renders a form for the user to put their email address in to receive the password reset email.
 > - The `create` action will send an email to the user containing a link that will allow them to reset the password. The link will contain their `password_reset_token` which is unique and expires. Note that we call `downcase` on the email to account for case sensitivity when searching.
 >   - You'll remember that the `password_reset_token` is a [signed_id](https://api.rubyonrails.org/classes/ActiveRecord/SignedId.html#method-i-signed_id), and is set to expire in 10 minutes. You'll also note that we need to pass the method `purpose: :reset_password` to be consistent with the purpose that was set in the `generate_password_reset_token` method. 
 >   - Note that we return `Invalid or expired token.` if the user is not found. This makes it difficult for a bad actor to use the reset form to see which email accounts exist on the application.
 > - The `edit` action simply renders the form for the user to update their password. It attempts to find a user by their `password_reset_token`. You can think of the `password_reset_token` as a way to identify the user much like how we normally identify records by their ID. However, the `password_reset_token` is randomly generated and will expire so it's more secure.
-> - The `new` action simply renders a form for the user to put their email address in to receive the password reset email.
 > - The `update` also ensures the user is identified by their `password_reset_token`. It's not enough to just do this on the `edit` action since a bad actor could make a `PUT` request to the server and bypass the form.
 >   - If the user exists and is confirmed we update their password to the one they will set in the form. Otherwise, we handle each failure case differently.
 

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,6 +1,10 @@
 class ConfirmationsController < ApplicationController
   before_action :redirect_if_authenticated, only: [:create, :new]
 
+  def new
+    @user = User.new
+  end
+  
   def create
     @user = User.find_by(email: params[:user][:email].downcase)
 
@@ -24,9 +28,5 @@ class ConfirmationsController < ApplicationController
     else
       redirect_to new_confirmation_path, alert: "Invalid token."
     end
-  end
-
-  def new
-    @user = User.new
   end
 end

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,6 +1,9 @@
 class PasswordsController < ApplicationController
   before_action :redirect_if_authenticated
 
+  def new
+  end
+  
   def create
     @user = User.find_by(email: params[:user][:email].downcase)
     if @user.present?
@@ -22,9 +25,6 @@ class PasswordsController < ApplicationController
     elsif @user.nil?
       redirect_to new_password_path, alert: "Invalid or expired token."
     end
-  end
-
-  def new
   end
 
   def update

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,6 +2,9 @@ class SessionsController < ApplicationController
   before_action :redirect_if_authenticated, only: [:create, :new]
   before_action :authenticate_user!, only: [:destroy]
 
+  def new
+  end
+  
   def create
     @user = User.authenticate_by(email: params[:user][:email].downcase, password: params[:user][:password])
     if @user
@@ -23,8 +26,5 @@ class SessionsController < ApplicationController
     forget_active_session
     logout
     redirect_to root_path, notice: "Signed out."
-  end
-
-  def new
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,10 @@ class UsersController < ApplicationController
   before_action :authenticate_user!, only: [:edit, :destroy, :update]
   before_action :redirect_if_authenticated, only: [:create, :new]
 
+  def new
+    @user = User.new
+  end
+
   def create
     @user = User.new(create_user_params)
     if @user.save
@@ -12,19 +16,9 @@ class UsersController < ApplicationController
     end
   end
 
-  def destroy
-    current_user.destroy
-    reset_session
-    redirect_to root_path, notice: "Your account has been deleted."
-  end
-
   def edit
     @user = current_user
     @active_sessions = @user.active_sessions.order(created_at: :desc)
-  end
-
-  def new
-    @user = User.new
   end
 
   def update
@@ -45,6 +39,12 @@ class UsersController < ApplicationController
       flash.now[:error] = "Incorrect password"
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    current_user.destroy
+    reset_session
+    redirect_to root_path, notice: "Your account has been deleted."
   end
 
   private


### PR DESCRIPTION
First of all, thanks for this guide. It's been super interesting going through it

I found the order of controller actions very strange because usually they go in pairs:
- `new` with `create`
- `edit` with `update`

And from a developer perspective, you build a `new` template (first) to be used by the `create` action (second). Having it backwards or sometimes mixed up is kind of strange.

The Rails scaffold generator uses another order where it put puts all `GET` requests first and all others second. However I find this one a bit more aligned with the developer's experience