### PR TITLE
Fix unconfirmed user alert message

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ class SessionsController < ApplicationController
     @user = User.find_by(email: params[:user][:email].downcase)
     if @user
       if @user.unconfirmed?
-        redirect_to new_confirmation_path, alert: "Incorrect email or password."
+        redirect_to new_confirmation_path, alert: "Please confirm your email first."
       elsif @user.authenticate(params[:user][:password])
         login @user
         redirect_to root_path, notice: "Signed in."
@@ -1283,7 +1283,7 @@ class SessionsController < ApplicationController
     @user = User.authenticate_by(email: params[:user][:email].downcase, password: params[:user][:password])
     if @user
       if @user.unconfirmed?
-        redirect_to new_confirmation_path, alert: "Incorrect email or password."
+        redirect_to new_confirmation_path, alert: "Please confirm your email first."
       else
         after_login_path = session[:user_return_to] || root_path
         login @user

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < ApplicationController
     @user = User.authenticate_by(email: params[:user][:email].downcase, password: params[:user][:password])
     if @user
       if @user.unconfirmed?
-        redirect_to new_confirmation_path, alert: "Incorrect email or password."
+        redirect_to new_confirmation_path, alert: "Please confirm your email first."
       else
         after_login_path = session[:user_return_to] || root_path
         active_session = login @user

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -68,7 +68,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
         password: @unconfirmed_user.password
       }
     }
-    assert_equal "Incorrect email or password.", flash[:alert]
+    assert_equal "Please confirm your email first.", flash[:alert]
     assert_nil current_user
     assert_redirected_to new_confirmation_path
   end


### PR DESCRIPTION
Thanks for the great guide!

Here is a little inconsistency that I found:

"Please confirm your email first." is used in the PasswordsController but not in the SessionsController.
The message used in the PasswordsController makes more sense.

Thanks again!