### PR TITLE
Adds current_active_session helper, memoization for current_user

### DIFF
--- a/app/controllers/active_sessions_controller.rb
+++ b/app/controllers/active_sessions_controller.rb
@@ -2,16 +2,16 @@ class ActiveSessionsController < ApplicationController
   before_action :authenticate_user!
 
   def destroy
-    @active_session = current_user.active_sessions.find(params[:id])
+    active_session = current_user.active_sessions.find(params[:id])
 
-    @active_session.destroy
-
-    if current_user
-      redirect_to account_path, notice: "Session deleted."
-    else
+    if active_session == current_active_session
       forget_active_session
+      active_session.destroy
       reset_session
       redirect_to root_path, notice: "Signed out."
+    else
+      active_session.destroy
+      redirect_to account_path, notice: "Session deleted."
     end
   end
 

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -3,6 +3,7 @@ module Authentication
 
   included do
     before_action :current_user
+    helper_method :current_active_session
     helper_method :current_user
     helper_method :user_signed_in?
   end
@@ -41,10 +42,14 @@ module Authentication
   private
 
   def current_user
-    Current.user = if session[:current_active_session_id].present?
-      ActiveSession.find_by(id: session[:current_active_session_id])&.user
+    Current.user ||= current_active_session&.user
+  end
+
+  def current_active_session
+    Current.active_session ||= if session[:current_active_session_id].present?
+      ActiveSession.find_by(id: session[:current_active_session_id])
     elsif cookies[:remember_token]
-      ActiveSession.find_by(remember_token: cookies.encrypted[:remember_token])&.user
+      ActiveSession.find_by(remember_token: cookies.encrypted[:remember_token])
     end
   end
 

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,3 +1,4 @@
 class Current < ActiveSupport::CurrentAttributes
   attribute :user
+  attribute :active_session
 end


### PR DESCRIPTION
Closes #93, "Why is the ||= removed? current_user method".  This adds memoization back to current_user / Current.user, plus causes log out when the current session is destroyed.

With this change, it's easy to find the current session and check its id against the param.  The user is logged out if the current session is destroyed, allowing the tests to pass with memoization in place.