### PR TITLE
Disallow confirmation token reuse

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -53,6 +53,6 @@ module Authentication
   end
 
   def store_location
-    session[:user_return_to] = request.original_url if request.get? && request.local?
+    session[:user_return_to] = request.original_url if request.get?
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -6,9 +6,10 @@ class UserMailer < ApplicationMailer
   #
   #   en.user_mailer.confirmation.subject
   #
-  def confirmation(user, confirmation_token)
+  def confirmation(user, confirmation_token, confirmable_email)
     @user = user
     @confirmation_token = confirmation_token
+    @confirmable_email = confirmable_email
 
     mail to: @user.confirmable_email, subject: "Confirmation Instructions"
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,8 +53,17 @@ class User < ApplicationRecord
     end
   end
 
+  def self.email_confirmation_purpose_for(email)
+    "confirm_email: #{email}"
+  end
+
+  def email_confirmation_purpose
+    self.class.email_confirmation_purpose_for(confirmable_email)
+  end
+
   def generate_confirmation_token
-    signed_id expires_in: CONFIRMATION_TOKEN_EXPIRATION, purpose: :confirm_email
+    signed_id expires_in: CONFIRMATION_TOKEN_EXPIRATION,
+      purpose: email_confirmation_purpose
   end
 
   def generate_password_reset_token
@@ -63,7 +72,7 @@ class User < ApplicationRecord
 
   def send_confirmation_email!
     confirmation_token = generate_confirmation_token
-    UserMailer.confirmation(self, confirmation_token).deliver_now
+    UserMailer.confirmation(self, confirmation_token, confirmable_email).deliver_now
   end
 
   def send_password_reset_email!

--- a/app/views/user_mailer/confirmation.html.erb
+++ b/app/views/user_mailer/confirmation.html.erb
@@ -1,3 +1,3 @@
 <h1>Confirmation Instructions</h1>
 
-<%= link_to "Click here to confirm your email.", edit_confirmation_url(@confirmation_token) %>
+<%= link_to "Click here to confirm your email.", edit_confirmation_url(@confirmation_token, email: @confirmable_email) %>

--- a/app/views/user_mailer/confirmation.text.erb
+++ b/app/views/user_mailer/confirmation.text.erb
@@ -1,3 +1,3 @@
 Confirmation Instructions
 
-<%= edit_confirmation_url(@confirmation_token) %>
+<%= edit_confirmation_url(@confirmation_token, email: @confirmable_email) %>

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -44,6 +44,12 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_not_nil current_user
     assert_not_nil cookies[:remember_token]
+
+    remember_me_cookie = cookies.get_cookie("remember_token")
+
+    assert remember_me_cookie.http_only?
+    assert remember_me_cookie.secure?
+    assert_equal "Strict", remember_me_cookie.to_h["SameSite"]
   end
 
   test "should forget user when logging out" do

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -7,7 +7,7 @@ class UserMailerTest < ActionMailer::TestCase
 
   test "confirmation" do
     confirmation_token = @user.generate_confirmation_token
-    mail = UserMailer.confirmation(@user, confirmation_token)
+    mail = UserMailer.confirmation(@user, confirmation_token, @user.unconfirmed_email)
     assert_equal "Confirmation Instructions", mail.subject
     assert_equal [@user.email], mail.to
     assert_equal [User::MAILER_FROM_EMAIL], mail.from


### PR DESCRIPTION
This fairly complex and kind of ugly change fixes the token reuse issue for email confirmation.