### PR TITLE
Adds security to the remember_token cookie.

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -35,7 +35,12 @@ module Authentication
   end
 
   def remember(active_session)
-    cookies.permanent.encrypted[:remember_token] = active_session.remember_token
+    cookies.permanent.encrypted[:remember_token] = {
+      value: active_session.remember_token,
+      secure: Rails.env.production?,
+      http_only: true,
+      same_site: :strict
+    }
   end
 
   private

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -44,6 +44,11 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_not_nil current_user
     assert_not_nil cookies[:remember_token]
+
+    remember_me_cookie = cookies.get_cookie("remember_token")
+
+    assert remember_me_cookie.http_only?
+    assert_equal "Strict", remember_me_cookie.to_h["SameSite"]
   end
 
   test "should forget user when logging out" do


### PR DESCRIPTION
1. set to "secure" in production
2. HttpOnly set to true
3. SameSite is now Strict